### PR TITLE
Fix the Verilog testbench's `$display` command so it can retrieve `argmax`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ hardware description language. Main features include:
    time 1930
    layer1 output:
    [  33  -48   29   58  -50   31  -87   93    9   49]
-   argmax: 7
+   argmax: [7]
 
    - pyrtl_inference_test.v:858: Verilog $finish
    - S i m u l a t i o n   R e p o r t: Verilator 5.032 2025-01-01

--- a/pyrtl_inference.py
+++ b/pyrtl_inference.py
@@ -16,9 +16,40 @@ from pyrtlnet.pyrtl_inference import PyRTLInference
 def main() -> None:
     parser = argparse.ArgumentParser(prog="pyrtl_inference.py")
     add_common_arguments(parser)
-    parser.add_argument("--verilog", action="store_true", default=False)
-    parser.add_argument("--axi", action="store_true", default=False)
-    parser.add_argument("--initial_delay_cycles", type=int, default=0)
+    parser.add_argument(
+        "--verilog",
+        action="store_true",
+        default=False,
+        help="""If enabled, export the pyrtlnet hardware design to a Verilog file. The
+             file will be named `pyrtl_inference.v` or `pyrtl_inference_axi.v`,
+             depending on `--axi`. A Verilog testbench will also be written, named
+             `pyrtl_inference_test.v` or `pyrtl_inference_axi_test.v`, which repeats the
+             `pyrtl_inference.py` simulation in Verilog.""",
+    )
+    parser.add_argument(
+        "--axi",
+        action="store_true",
+        default=False,
+        help="""If enabled, transmit image data via AXI-Stream and receive layer outputs
+             via AXI-Lite. This is synthesizable, but more complicated. If disabled,
+             `Simulation` initializes memories with image data, and retrieves layer
+             outputs by inspecting registers. This is not synthesizable, and is less
+             complicated.""",
+    )
+    parser.add_argument(
+        "--simulation",
+        type=str,
+        default="FastSimulation",
+        help="""Name of the PyRTL `Simulation` class to instantiate. Valid values are
+             `Simulation`, `FastSimulation`, and `CompiledSimulation`.""",
+    )
+    parser.add_argument(
+        "--initial_delay_cycles",
+        type=int,
+        default=0,
+        help="""A hack which should not be necessary. Currently required for correct
+             FPGA synthesis.""",
+    )
     args = parser.parse_args()
 
     # Validate arguments.
@@ -52,7 +83,7 @@ def main() -> None:
     ):
         # Run PyRTL inference on the test image.
         layer0_outputs, layer1_outputs, actual = pyrtl_inference.simulate(
-            test_batch, args.verilog
+            test_batch, args.verilog, args.verbose, args.simulation
         )
 
         # Display the test image.

--- a/pyrtl_matrix.py
+++ b/pyrtl_matrix.py
@@ -66,8 +66,20 @@ def main() -> None:
     parser.add_argument("--y_zero", type=int, default=0)
     parser.add_argument("--a_shape", type=int, nargs=2, default=(2, 4))
     parser.add_argument("--a_start", type=int, default=1)
-    parser.add_argument("--verilog", action="store_true", default=False)
-    parser.add_argument("--initial_delay_cycles", type=int, default=0)
+    parser.add_argument(
+        "--verilog",
+        action="store_true",
+        default=False,
+        help="""If enabled, export the `pyrtl_matrix` hardware and its testbench to a
+             Verilog file. The file will be named `pyrtl_matrix.v`.""",
+    )
+    parser.add_argument(
+        "--initial_delay_cycles",
+        type=int,
+        default=0,
+        help="""A hack which should not be necessary. Currently required for correct
+             FPGA synthesis.""",
+    )
     args = parser.parse_args()
 
     # Create input matrices.

--- a/pyrtlnet/cli_util.py
+++ b/pyrtlnet/cli_util.py
@@ -298,7 +298,7 @@ class PrintElapsedTime:
 
     Example output::
 
-        Sleeping... done (2.0 seconds)
+        Sleeping... done (2.00 seconds)
     """
 
     def __init__(self, message: str) -> None:
@@ -313,4 +313,13 @@ class PrintElapsedTime:
         print(f"{self.message}... ", end="", flush=True)
 
     def __exit__(self, *exception_info) -> None:  #  noqa: ANN002
-        print(f"done ({time.time() - self.start:.1f} seconds)")
+        elapsed = time.time() - self.start
+        units = "s"
+
+        if elapsed < 0.001:
+            elapsed *= 1_000_000
+            units = "µs"
+        elif elapsed < 1:
+            elapsed *= 1000
+            units = "ms"
+        print(f"done ({elapsed:.2f} {units})")

--- a/pyrtlnet/inference_util.py
+++ b/pyrtlnet/inference_util.py
@@ -21,8 +21,7 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
         type=int,
         default=0,
         help="""Index of the first image to run in the MNIST test data set. Must be
-             less than the number of images in the test data set (10000).
-             """,
+             less than the number of images in the test data set (10000).""",
     )
     parser.add_argument(
         "--num_images",
@@ -30,25 +29,24 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
         default=1,
         help="""Number of images to run. If the last image in the MNIST test data set is
              reached, processing will stop. When processing stops this way, fewer than
-             `num_images` may be processed.
-             """,
+             `num_images` may be processed.""",
     )
     parser.add_argument(
         "--batch_size",
         type=int,
         default=1,
         help="""Number of images to process per batch. If `batch_size > num_images`, the
-             model will process up to `num_images`. If `num_images %% batch_size != 0`,
-             the last batch will be of size `num_images %% batch_size`.
-             """,
+             model will process up to `num_images`. If `num_images` is not evenly
+             divisible by `batch_size`, the last batch will contain
+             `num_images %% batch_size` images. Any unused image slots in the last batch
+             will be zeroed out.""",
     )
     parser.add_argument(
         "--tensor_path",
         type=str,
         default=".",
         help="""Name of the directory containing the quantized weights and preprocessed
-             MNIST test data produced by `tensorflow_training.py`.
-             """,
+             MNIST test data produced by `tensorflow_training.py`.""",
     )
     parser.add_argument("--verbose", action=argparse.BooleanOptionalAction)
 

--- a/pyrtlnet/pyrtl_inference.py
+++ b/pyrtlnet/pyrtl_inference.py
@@ -14,12 +14,14 @@ inference with `PyRTL`_.
 """
 
 import pathlib
+from contextlib import nullcontext
 
 import numpy as np
 import pyrtl
 
 import pyrtlnet.pyrtl_axi as pyrtl_axi
 import pyrtlnet.pyrtl_matrix as pyrtl_matrix
+from pyrtlnet.cli_util import PrintElapsedTime
 from pyrtlnet.constants import quantized_model_prefix
 from pyrtlnet.inference_util import preprocess_image
 from pyrtlnet.saved_tensors import SavedTensors
@@ -281,11 +283,14 @@ class PyRTLInference:
         self.layer_outputs = [layer0, layer1]
 
         # Compute argmax for the last layer's output.
-        BatchArgmaxValues = pyrtl.wire_matrix(component_schema=4, size=self.batch_size)
-
         argmax_values = pyrtl_matrix.make_argmax(a=layer1)
 
-        BatchArgmaxValues(name="argmax_out", values=argmax_values)
+        # Create Outputs for the argmaxes.
+        argmax_outputs = []
+        for i in range(self.batch_size):
+            argmax_output = pyrtl.Output(name=f"argmax_{i}", bitwidth=4)
+            argmax_output <<= argmax_values[i]
+            argmax_outputs.append(argmax_output)
 
         # Make a PyRTL Output for the second layer output's `valid` signal. When this
         # signal goes high, inference is complete.
@@ -358,8 +363,22 @@ class PyRTLInference:
 
         return data
 
+    def make_simulation(self, simulation_name: str) -> object:
+        if simulation_name == "Simulation":
+            return pyrtl.Simulation
+        if simulation_name == "FastSimulation":
+            return pyrtl.FastSimulation
+        if simulation_name == "CompiledSimulation":
+            return pyrtl.CompiledSimulation
+        msg = f"Unknown simulator type '{simulation_name}'"
+        raise AssertionError(msg)
+
     def simulate(
-        self, test_batch: np.ndarray, verilog: bool = False
+        self,
+        test_batch: np.ndarray,
+        verilog: bool = False,
+        verbose: bool = False,
+        simulation_name: str = "FastSimulation",
     ) -> tuple[np.ndarray, np.ndarray, int]:
         """Simulate quantized inference on an image batch.
 
@@ -373,13 +392,16 @@ class PyRTLInference:
             ``pyrtl_inference.v``, or ``pyrtl_inference_axi.v`` when constructed with
             ``axi=True``. The testbench will be named ``pyrtl_inference_test.v``, or
             ``pyrtl_inference_axi_test.v`` when constructed with ``axi=True``.
+        :param verbose: If ``True``, print simulation timing statistics.
+        :param simulation_name: Name of the PyRTL Simulation class to instantiate for
+            simulation. Valid options are ``Simulation``, ``FastSimulation``, and
+            ``CompiledSimulation``.
 
-        :returns: ``(layer0_output, layer1_output, argmax)``, where
-                  ``layer0_output`` is the first layer's raw tensor output, with shape
-                  ``(batch_size, 18)``.
-                  ``layer1_output`` is the second layer's raw tensor output,
-                  with shape ``(batch_size, 10)``. ``argmax`` is a list of predicted
-                  digits for each image in the batch, with length ``batch_size``.
+        :returns: ``(layer0_output, layer1_output, argmax)``, where ``layer0_output`` is
+                  the first layer's raw tensor output, with shape ``(batch_size, 18)``.
+                  ``layer1_output`` is the second layer's raw tensor output, with shape
+                  ``(batch_size, 10)``. ``argmax`` is a list of predicted digits for
+                  each image in the batch, with length ``batch_size``.
         """
         memblock_data = self._memblock_data(test_batch)
 
@@ -387,8 +409,13 @@ class PyRTLInference:
         # to make a new `FastSimulation` for each batch. Update the
         # `axi_stream_subordinate` and `systolic_array` state machines so they reset
         # after processing one batch.
+        constructor_context = nullcontext()
+        if verbose:
+            constructor_context = PrintElapsedTime(f"Constructing {simulation_name}")
+        simulation = self.make_simulation(simulation_name)
         if self.axi:
-            sim = pyrtl.FastSimulation()
+            with constructor_context:
+                sim = simulation()
 
             # `provided_inputs` holds default values for all Inputs. `aresetn` is active
             # low.
@@ -419,16 +446,21 @@ class PyRTLInference:
             )
         else:
             memblock_data_dict = dict(enumerate(memblock_data))
-            sim = pyrtl.FastSimulation(
-                memory_value_map={self.flat_batch_memblock: memblock_data_dict}
-            )
+            with constructor_context:
+                sim = simulation(
+                    memory_value_map={self.flat_batch_memblock: memblock_data_dict}
+                )
             provided_inputs = {}
 
         # Wait until the second layer's computations are done.
-        done = False
-        while not done:
-            sim.step(provided_inputs)
-            done = sim.inspect("valid")
+        step_context = nullcontext()
+        if verbose:
+            step_context = PrintElapsedTime(f"Stepping {simulation_name}")
+        with step_context:
+            done = False
+            while not done:
+                sim.step(provided_inputs)
+                done = sim.inspect("valid")
 
         # Retrieve each layer's outputs and the predicted digit(s).
         if self.axi:
@@ -489,7 +521,7 @@ class PyRTLInference:
             layer1_output = self.layer_outputs[1].inspect(sim=sim).astype(np.int8)
             argmax = []
             for i in range(self.batch_size):
-                argmax.append(sim.inspect(f"argmax_out[{i}]"))
+                argmax.append(sim.inspect(f"argmax_{i}"))
 
         if verilog:
             suffix = ""
@@ -499,6 +531,28 @@ class PyRTLInference:
             with open(module_file_name, "w") as output:
                 pyrtl.output_to_verilog(output, add_reset=False)
             with open(f"pyrtl_inference{suffix}_test.v", "w") as output:
+                layer1_format = ""
+                layer1_names = ""
+                if not self.axi:
+                    layer1_format = (
+                        "layer1 output:\\n[%4d %4d %4d %4d %4d %4d %4d %4d %4d %4d]\\n"
+                    )
+                    layer1_names = (
+                        ", $signed(layer1_0_0), $signed(layer1_1_0), "
+                        "$signed(layer1_2_0), $signed(layer1_3_0), "
+                        "$signed(layer1_4_0), $signed(layer1_5_0), "
+                        "$signed(layer1_6_0), $signed(layer1_7_0), "
+                        "$signed(layer1_8_0), $signed(layer1_9_0)"
+                    )
+
+                argmax_formats = []
+                argmax_names = []
+                for i in range(self.batch_size):
+                    argmax_formats.append("%1d")
+                    argmax_names.append(f"argmax_{i}")
+
+                argmax_formats = " ".join(argmax_formats)
+                argmax_names = f", {', '.join(argmax_names)}"
                 pyrtl.output_verilog_testbench(
                     output,
                     simulation_trace=sim.tracer,
@@ -506,16 +560,9 @@ class PyRTLInference:
                     vcd=f"pyrtl_inference{suffix}.vcd",
                     cmd=(
                         '$display("time %3t\\n'
-                        "layer1 output:\\n"
-                        "[%4d %4d %4d %4d %4d %4d %4d %4d %4d %4d]\\n"
-                        'argmax: %1d\\n", '
-                        "$time,"
-                        "$signed(layer1_0_0), $signed(layer1_1_0), "
-                        "$signed(layer1_2_0), $signed(layer1_3_0), "
-                        "$signed(layer1_4_0), $signed(layer1_5_0), "
-                        "$signed(layer1_6_0), $signed(layer1_7_0), "
-                        "$signed(layer1_8_0), $signed(layer1_9_0), "
-                        "argmax);"
+                        f"{layer1_format}"
+                        f'argmax: [{argmax_formats}]\\n", '
+                        f"$time{layer1_names}{argmax_names});"
                     ),
                     add_reset=False,
                 )

--- a/tensorflow_training.py
+++ b/tensorflow_training.py
@@ -13,7 +13,14 @@ from pyrtlnet.training_util import save_mnist_data
 
 def main() -> None:
     parser = argparse.ArgumentParser(prog="tensorflow_training.py")
-    parser.add_argument("--tensor_path", type=str, default=".")
+    parser.add_argument(
+        "--tensor_path",
+        type=str,
+        default=".",
+        help="""Name of the directory where quantized weights and preprocessed MNIST
+        test data will be saved. The inference scripts will load this data from this
+        directory.""",
+    )
     args = parser.parse_args()
 
     # Load MNIST dataset.


### PR DESCRIPTION
This restores the `argmax` `Output`s, which were lost at some point. The Verilog testbench's `$display` command depended on these `argmax` `Output`s, so the testbench was not working without this commit.

This disables the Verilog layer output display when `--axi` is enabled, as we can't easily `$display` the layer outputs with `--axi`. This commit makes the Verilog testbenches work with and without `--axi`.

Add more flag `--help` documentation.

Add a `--simulation` argument to `pyrtl_inference.py`, which lets users easily try other PyRTL `Simulation` implementations like `CompiledSimulation`.

Add basic simulation time logging. This prints the simulation's run time, broken up into construction time and step time. Construction time is the simulator's start-up time, while step time is the time spent actually simulating cycles.